### PR TITLE
Add new CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,34 @@
+cff-version: 1.2.0
+message: 'If you use this software, please cite it as below.'
+type: software
+title: 'jaxDecomp: JAX Library for 3D Domain Decomposition and Parallel FFTs'
+authors:
+  - family-names: "Kabalan"
+    given-names: "Wassim"
+    orcid: "https://orcid.org/0009-0001-6501-4564"
+  - family-names: "Lanusse"
+    given-names: "Francois"
+    orcid: "https://orcid.org/0000-0001-7956-0542"
+repository-code: 'https://github.com/DifferentiableUniverseInitiative/jaxDecomp'
+url: 'https://jaxdecomp.readthedocs.io'
+abstract: >-
+  JAX reimplementation and bindings for NVIDIA's cuDecomp library,
+  enabling multi-node parallel FFTs and halo exchanges directly in
+  low-level NCCL/CUDA-Aware MPI from JAX code. jaxDecomp provides
+  both a pure JAX backend for easy deployment and an optional
+  cuDecomp backend for advanced MPI/NCCL communication patterns.
+  All functions are JIT-compatible and support automatic differentiation.
+keywords:
+  - JAX
+  - domain decomposition
+  - parallel FFT
+  - distributed computing
+  - MPI
+  - NCCL
+  - GPU computing
+  - cuDecomp
+  - halo exchange
+  - HPC
+license: MIT
+version: 0.2.8
+date-released: '2025-01-01'


### PR DESCRIPTION
This pull request adds a `CITATION.cff` file to the repository, providing a standardized citation for the `jaxDecomp` software. This makes it easier for users to properly cite the project in academic works and ensures compliance with best practices for research software.

Documentation and citation:

* Added a `CITATION.cff` file with citation information, including title, authors, repository link, abstract, keywords, license, version, and release date for the `jaxDecomp` project.