### PR TITLE
Fix build for pypi upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
           # Drive scikit-build-core through uv as the in-container build frontend.
           CIBW_BUILD_FRONTEND: "build[uv]"
           CIBW_ENVIRONMENT: >-
-            PIP_ONLY_BINARY=scipy,numpy
+            PIP_ONLY_BINARY=:all:
+            PIP_PREFER_BINARY=1
             SETUPTOOLS_SCM_PRETEND_VERSION_FOR_JAXDECOMP=${{ steps.version.outputs.value }}
           # Belt-and-suspenders: if PRETEND_VERSION is ever empty, setuptools_scm falls back
           # to `git describe` inside the container (root over a mounted checkout).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "nanobind>=1.3.2", "jax>=0.4.35", "setuptools_scm>=8"]
+requires = ["scikit-build-core>=0.10", "nanobind>=1.3.2", "jax>=0.11.1", "setuptools_scm>=8"]
 build-backend = "scikit_build_core.build"
 [project]
 name = "jaxdecomp"


### PR DESCRIPTION
This pull request updates the build configuration and dependencies to improve binary installation reliability and ensure compatibility with newer versions of JAX. The most important changes are:

Dependency updates:

* Updated the `jax` dependency in `pyproject.toml` from version `0.4.35` to `0.11.1` to ensure compatibility with the latest features and bug fixes.

Build configuration improvements:

* Changed the `PIP_ONLY_BINARY` environment variable in the GitHub Actions workflow to `:all:` and set `PIP_PREFER_BINARY=1` to prefer and enforce binary wheels for all dependencies during builds, improving build reliability and speed.