### PR TITLE
Fix error with jvp/vjp with new primitives

### DIFF
--- a/src/jaxdecomp/_src/cudecomp/fft.py
+++ b/src/jaxdecomp/_src/cudecomp/fft.py
@@ -10,6 +10,7 @@ from jax._src.interpreters import ad, mlir
 from jax._src.numpy.util import promote_dtypes_complex
 from jax.core import ShapedArray
 from jax.experimental.hijax import VJPHiPrimitive as HiPrim
+from jax.experimental.hijax import linearize_from_jvp
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxdecomplib import _jaxdecomp
@@ -482,6 +483,8 @@ class PfftHiPrim(HiPrim):
         y = self.expand(x)
         y_dot = self.expand(x_dot)
         return y, y_dot
+
+    lin, linearized = linearize_from_jvp
 
     def vjp_fwd(self, nzs_in, x):
         return self.expand(x), (self.params['fft_type'], self.params['adjoint'])

--- a/src/jaxdecomp/_src/cudecomp/halo.py
+++ b/src/jaxdecomp/_src/cudecomp/halo.py
@@ -10,6 +10,7 @@ from jax._src.interpreters import ad, mlir
 from jax._src.typing import Array
 from jax.core import ShapedArray
 from jax.experimental.hijax import VJPHiPrimitive as HiPrim
+from jax.experimental.hijax import linearize_from_jvp
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxdecomplib import _jaxdecomp
@@ -435,6 +436,8 @@ class HaloExchangeHiPrim(HiPrim):
         y = self.expand(x)
         y_dot = self.expand(x_dot)
         return y, y_dot
+
+    lin, linearized = linearize_from_jvp
 
     def vjp_fwd(self, nzs_in, x):
         return self.expand(x), x

--- a/src/jaxdecomp/_src/cudecomp/transpose.py
+++ b/src/jaxdecomp/_src/cudecomp/transpose.py
@@ -11,6 +11,7 @@ from jax._src.lib.mlir.dialects import hlo
 from jax._src.typing import Array, ArrayLike
 from jax.core import ShapedArray
 from jax.experimental.hijax import VJPHiPrimitive as HiPrim
+from jax.experimental.hijax import linearize_from_jvp
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxdecomplib import _jaxdecomp
@@ -556,6 +557,8 @@ class TransposeHiPrim(HiPrim):
         y = self.expand(x)
         y_dot = self.expand(x_dot)
         return y, y_dot
+
+    lin, linearized = linearize_from_jvp
 
     def vjp_fwd(self, nzs_in, x):
         return self.expand(x), None

--- a/src/jaxdecomp/_src/jax/fft.py
+++ b/src/jaxdecomp/_src/jax/fft.py
@@ -7,6 +7,7 @@ from jax._src.core import ShapedArray
 from jax._src.interpreters import batching
 from jax._src.typing import Array
 from jax.experimental.hijax import VJPHiPrimitive as HiPrim
+from jax.experimental.hijax import linearize_from_jvp
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxdecomplib import _jaxdecomp
@@ -612,6 +613,8 @@ class PfftHiPrim(HiPrim):
         y = self(x)
         y_dot = self(x_dot)
         return y, y_dot
+
+    lin, linearized = linearize_from_jvp
 
     def vjp_fwd(self, nzs_in, x):
         return self(x), (self.params['fft_type'], self.params['adjoint'])

--- a/src/jaxdecomp/_src/jax/halo.py
+++ b/src/jaxdecomp/_src/jax/halo.py
@@ -5,6 +5,7 @@ from jax import ShapeDtypeStruct, lax
 from jax._src.interpreters import batching
 from jax.core import ShapedArray
 from jax.experimental.hijax import VJPHiPrimitive as HiPrim
+from jax.experimental.hijax import linearize_from_jvp
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxdecomplib import _jaxdecomp
@@ -507,6 +508,8 @@ class HaloExchangeHiPrim(HiPrim):
         y = self(x)
         y_dot = self(x_dot)
         return y, y_dot
+
+    lin, linearized = linearize_from_jvp
 
     def vjp_fwd(self, nzs_in, x):
         return self(x), x

--- a/src/jaxdecomp/_src/jax/transpose.py
+++ b/src/jaxdecomp/_src/jax/transpose.py
@@ -6,6 +6,7 @@ from jax._src.interpreters import batching
 from jax._src.typing import Array, ArrayLike
 from jax.core import ShapedArray
 from jax.experimental.hijax import VJPHiPrimitive as HiPrim
+from jax.experimental.hijax import linearize_from_jvp
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
@@ -359,6 +360,8 @@ class TransposeHiPrim(HiPrim):
         y = self(x)
         y_dot = self(x_dot)
         return y, y_dot
+
+    lin, linearized = linearize_from_jvp
 
     def vjp_fwd(self, nzs_in, x):
         return self(x), None

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -309,6 +309,54 @@ class TestFFTsGrad:
         global_shape = (4, 4, 4)
         self._run_hessian_test(pdims, global_shape, local_transpose, 'cuDecomp', use_shardy, axis_type)
 
+    def _run_linearize_test(self, local_transpose, use_shardy, backend):
+        """Test that jax.linearize works with FFT (the HiPrim `lin`/`linearized` rules).
+
+        The linearized map must agree with the jvp rule (the FFT is linear) and satisfy
+        the transpose dot-product test ⟨w, J v⟩ == ⟨Jᵀ w, v⟩.
+        """
+        if use_shardy and not ALLOW_SHARDY_PARTITIONER:
+            pytest.skip(reason='Shardy partitioner is not supported in this JAX version use at least JAX 0.7.0')
+
+        jaxdecomp.config.update('transpose_axis_contiguous', local_transpose)
+        jax.config.update('jax_use_shardy_partitioner', use_shardy)
+
+        def f(arr):
+            return jaxdecomp.fft.pfft3d(arr, backend=backend)
+
+        # Small non-distributed array, like the hessian test
+        x = jax.random.normal(jax.random.PRNGKey(0), (4, 4, 4), dtype=jnp.float64)
+        v = jax.random.normal(jax.random.PRNGKey(1), x.shape, dtype=x.dtype)
+
+        # jax.linearize requires the HiPrim `lin`/`linearized` rules
+        _, lin_fn = jax.linearize(f, x)
+
+        # The linearized map must agree with the jvp rule (the FFT is linear)
+        _, Jv_jvp = jax.jvp(f, (x,), (v,))
+        Jv_lin = lin_fn(v)
+        assert assert_allclose(Jv_jvp, Jv_lin, rtol=1e-5, atol=1e-5)
+
+        # Transpose dot-product test: Re[wᵀ(J v)] == (Jᵀ w)ᵀv — the real part of the bilinear
+        # pairing, which is the transpose contract jax.linear_transpose defines for complex
+        # outputs on real inputs (the returned cotangent Jᵀ w is real).
+        w = jax.random.normal(jax.random.PRNGKey(2), Jv_lin.shape, dtype=Jv_lin.dtype)
+        _, vjp_fn = jax.vjp(f, x)
+        (JTw,) = vjp_fn(w)
+        assert assert_allclose(jnp.sum(w * Jv_lin).real, jnp.sum(JTw * v), rtol=1e-5, atol=1e-5)
+
+    @pytest.mark.parametrize('use_shardy', use_shardy)
+    @pytest.mark.parametrize('local_transpose', local_transpose)
+    def test_jax_linearize(self, local_transpose, use_shardy):
+        """Test that jax.linearize works with FFT (JAX backend)."""
+        self._run_linearize_test(local_transpose, use_shardy, 'jax')
+
+    @pytest.mark.skipif(not is_on_cluster(), reason='Only run on cluster')
+    @pytest.mark.parametrize('use_shardy', use_shardy)
+    @pytest.mark.parametrize('local_transpose', local_transpose)
+    def test_cudecomp_linearize(self, local_transpose, use_shardy):
+        """Test that jax.linearize works with FFT (cuDecomp backend)."""
+        self._run_linearize_test(local_transpose, use_shardy, 'cuDecomp')
+
     @pytest.mark.skipif(not is_on_cluster(), reason='Only run on cluster')
     @pytest.mark.parametrize('local_transpose', local_transpose)  # Test with and without local transpose
     @pytest.mark.parametrize('pdims', decomp)  # Test with Slab and Pencil decompositions

--- a/tests/test_halo.py
+++ b/tests/test_halo.py
@@ -440,6 +440,66 @@ class TestHaloExchangeGrad:
     def test_cudecomp_hessian(self, pdims, use_shardy, axis_type):
         self._run_hessian_test(pdims, 'CUDECOMP', use_shardy, axis_type)
 
+    def _run_linearize_test(self, pdims, backend, use_shardy):
+        """Test that jax.linearize works with halo exchange (the HiPrim `lin`/`linearized` rules).
+
+        The linearized map must agree with the jvp rule (halo exchange is linear) and
+        satisfy the transpose dot-product test ⟨w, J v⟩ == ⟨Jᵀ w, v⟩.
+        """
+        jax.config.update('jax_use_shardy_partitioner', use_shardy)
+
+        if use_shardy and not ALLOW_SHARDY_PARTITIONER:
+            pytest.skip(reason='Shardy partitioner is not supported in this JAX version use at least JAX 0.7.0')
+
+        halo_size = 2
+
+        halo_x = (halo_size, halo_size) if pdims[0] > 1 else (0, 0)
+        halo_y = (halo_size, halo_size) if pdims[1] > 1 else (0, 0)
+        halo_extents = (halo_x[0], halo_y[0])
+        periodic = (True, True)
+        padding = (halo_x, halo_y, (0, 0))
+
+        def f(arr):
+            return jaxdecomp.halo_exchange(arr, halo_extents=halo_extents, halo_periods=periodic, backend=backend)
+
+        # Small non-distributed array, like the hessian test
+        padded = jnp.pad(
+            jax.random.normal(jax.random.PRNGKey(0), (16, 16, 16), dtype=jnp.float64),
+            padding,
+            mode='linear_ramp',
+            end_values=20,
+        )
+        v = jax.random.normal(jax.random.PRNGKey(1), padded.shape, dtype=padded.dtype)
+
+        # jax.linearize requires the HiPrim `lin`/`linearized` rules
+        _, lin_fn = jax.linearize(f, padded)
+
+        # The linearized map must agree with the jvp rule (halo exchange is linear)
+        _, Jv_jvp = jax.jvp(f, (padded,), (v,))
+        Jv_lin = lin_fn(v)
+        assert assert_allclose(Jv_jvp, Jv_lin, rtol=1e-5, atol=1e-5)
+
+        # Transpose dot-product test: Re[wᵀ(J v)] == (Jᵀ w)ᵀv — the real part of the bilinear
+        # pairing, which is the transpose contract jax.linear_transpose defines for complex
+        # outputs on real inputs (the returned cotangent Jᵀ w is real).
+        w = jax.random.normal(jax.random.PRNGKey(2), Jv_lin.shape, dtype=Jv_lin.dtype)
+        _, vjp_fn = jax.vjp(f, padded)
+        (JTw,) = vjp_fn(w)
+        assert assert_allclose(jnp.sum(w * Jv_lin).real, jnp.sum(JTw * v), rtol=1e-5, atol=1e-5)
+
+    @pytest.mark.parametrize('use_shardy', use_shardy)
+    @pytest.mark.parametrize('pdims', pdims)
+    def test_jax_linearize(self, pdims, use_shardy):
+        """Test that jax.linearize works with halo exchange (JAX backend)."""
+        self._run_linearize_test(pdims, 'JAX', use_shardy)
+
+    @pytest.mark.skipif(not is_on_cluster(), reason='Only run on cluster')
+    @pytest.mark.parametrize('use_shardy', use_shardy)
+    @pytest.mark.parametrize('pdims', pdims)
+    def test_cudecomp_linearize(self, pdims, use_shardy):
+        """Test that jax.linearize works with halo exchange (cuDecomp backend)."""
+        self._run_linearize_test(pdims, 'CUDECOMP', use_shardy)
+
     @pytest.mark.parametrize('use_shardy', use_shardy)  # Test with and without shardy
     @pytest.mark.parametrize('pdims', pdims)
     def test_jax_halo(

--- a/tests/test_transpose.py
+++ b/tests/test_transpose.py
@@ -314,6 +314,54 @@ class TestTransposesGrad:
         global_shape = (4, 4, 4)
         self._run_hessian_test(pdims, global_shape, local_transpose, 'cuDecomp', use_shardy, axis_type)
 
+    def _run_linearize_test(self, local_transpose, use_shardy, backend):
+        """Test that jax.linearize works with transpose (the HiPrim `lin`/`linearized` rules).
+
+        The linearized map must agree with the jvp rule (the transpose is linear) and
+        satisfy the transpose dot-product test ⟨w, J v⟩ == ⟨Jᵀ w, v⟩.
+        """
+        if use_shardy and not ALLOW_SHARDY_PARTITIONER:
+            pytest.skip(reason='Shardy partitioner is not supported in this JAX version use at least JAX 0.7.0')
+
+        jaxdecomp.config.update('transpose_axis_contiguous', local_transpose)
+        jax.config.update('jax_use_shardy_partitioner', use_shardy)
+
+        def f(arr):
+            return transposeXtoY(arr, backend=backend)
+
+        # Small non-distributed array, like the hessian test
+        x = jax.random.normal(jax.random.PRNGKey(0), (4, 4, 4), dtype=jnp.float64)
+        v = jax.random.normal(jax.random.PRNGKey(1), x.shape, dtype=x.dtype)
+
+        # jax.linearize requires the HiPrim `lin`/`linearized` rules
+        _, lin_fn = jax.linearize(f, x)
+
+        # The linearized map must agree with the jvp rule (the transpose is linear)
+        _, Jv_jvp = jax.jvp(f, (x,), (v,))
+        Jv_lin = lin_fn(v)
+        assert assert_allclose(Jv_jvp, Jv_lin, rtol=1e-5, atol=1e-5)
+
+        # Transpose dot-product test: Re[wᵀ(J v)] == (Jᵀ w)ᵀv — the real part of the bilinear
+        # pairing, which is the transpose contract jax.linear_transpose defines for complex
+        # outputs on real inputs (the returned cotangent Jᵀ w is real).
+        w = jax.random.normal(jax.random.PRNGKey(2), Jv_lin.shape, dtype=Jv_lin.dtype)
+        _, vjp_fn = jax.vjp(f, x)
+        (JTw,) = vjp_fn(w)
+        assert assert_allclose(jnp.sum(w * Jv_lin).real, jnp.sum(JTw * v), rtol=1e-5, atol=1e-5)
+
+    @pytest.mark.parametrize('use_shardy', use_shardy)
+    @pytest.mark.parametrize('local_transpose', local_transpose)
+    def test_jax_linearize(self, local_transpose, use_shardy):
+        """Test that jax.linearize works with transpose (JAX backend)."""
+        self._run_linearize_test(local_transpose, use_shardy, 'jax')
+
+    @pytest.mark.skipif(not is_on_cluster(), reason='Only run on cluster')
+    @pytest.mark.parametrize('use_shardy', use_shardy)
+    @pytest.mark.parametrize('local_transpose', local_transpose)
+    def test_cudecomp_linearize(self, local_transpose, use_shardy):
+        """Test that jax.linearize works with transpose (cuDecomp backend)."""
+        self._run_linearize_test(local_transpose, use_shardy, 'cuDecomp')
+
     @pytest.mark.skipif(not is_on_cluster(), reason='Only run on cluster')
     # Cartesian product test
     @pytest.mark.parametrize('pdims', decomp)


### PR DESCRIPTION
fix error 

```
  jax._src.source_info_util.JaxStackTraceBeforeTransformation: NotImplementedError: for linearize support, subclass <class 'jaxdecomp._src.jax.fft.PfftHiPrim'> must implement `lin` and `linearized`, or derive them from its `jvp` rule by setting `lin, linearized = linearize_from_jvp
```
with new hijax primitives